### PR TITLE
Use licensing feature

### DIFF
--- a/features/org.palladiosimulator.scheduler.feature/feature.xml
+++ b/features/org.palladiosimulator.scheduler.feature/feature.xml
@@ -2,19 +2,18 @@
 <feature
       id="org.palladiosimulator.scheduler.feature"
       label="Scheduler Implementation for Palladio Simulator"
-      version="4.1.1.qualifier">
+      version="4.1.1.qualifier"
+      plugin="org.palladiosimulator.branding"
+      license-feature="org.palladiosimulator.license"
+      license-feature-version="1.0.0">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]
    </description>
 
-   <copyright url="http://www.example.com/copyright">
-      [Enter Copyright Description here.]
-   </copyright>
-
-   <license url="http://www.example.com/license">
-      [Enter License Description here.]
-   </license>
+   <requires>
+      <import plugin="org.palladiosimulator.branding"/>
+   </requires>
 
    <plugin
          id="de.uka.ipd.sdq.scheduler"


### PR DESCRIPTION
During installation, no license is shown for the scheduler feature. This PR applies the licensing feature to the feature.